### PR TITLE
remove subscription_id and update readme

### DIFF
--- a/c2-generic-variables.tf
+++ b/c2-generic-variables.tf
@@ -13,8 +13,3 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
-
-variable "subscription_id" {
-  description = "The Azure subscription ID where the resources will be created."
-  type        = string
-}

--- a/c7-servicebus-data.tf
+++ b/c7-servicebus-data.tf
@@ -1,9 +1,12 @@
+# Declare the data source to get the current client configuration
+data "azurerm_client_config" "current" {}
+
 # List all private DNS zones in the resource group (never fails)
 data "azapi_resource_list" "all_private_dns_zones" {
   count = local.is_private ? 1 : 0
   
   type                   = "Microsoft.Network/privateDnsZones@2020-06-01"
-  parent_id              = "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group_name}"
+  parent_id              = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}"
   response_export_values = ["*"]
 }
 
@@ -12,6 +15,6 @@ data "azapi_resource_list" "dns_zone_links" {
   count = local.is_private ? 1 : 0
   
   type                   = "Microsoft.Network/privateDnsZones/virtualNetworkLinks@2020-06-01"
-  parent_id              = "/subscriptions/${var.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Network/privateDnsZones/${local.private_dns_zone_name}"
+  parent_id              = "/subscriptions/${data.azurerm_client_config.current.subscription_id}/resourceGroups/${var.resource_group_name}/providers/Microsoft.Network/privateDnsZones/${local.private_dns_zone_name}"
   response_export_values = ["*"]
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Automatically uses the current Azure subscription; no manual subscription_id required.
  - Added debugging outputs for private DNS zone management.

- Documentation
  - Updated examples to remove subscription_id and clarify provider behavior.
  - Expanded Premium SKU guidance: namespace-level capacity/partitions; queue/topic partitioning inputs not applicable.
  - Added reminder and example for required Microsoft.ServiceBus service endpoints on subnets in service/private modes.
  - Detailed discovery and creation logic for intelligent private DNS zones and VNet link management, with idempotency notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->